### PR TITLE
Fix #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Options:
   -s, --indent-spaces <num_spaces>  Number of spaces of indentation for package.json (default: 4)
   -i, --version-increment [level]   Version increment level (default: "patch")
   -V, --verbose                     Verbose mode
+  -U, --upgrade-level [level]       Dependency version upgrade level (default: "major")
   -h, --help                        output usage information
 
 Examples:

--- a/bin/updep.js
+++ b/bin/updep.js
@@ -12,6 +12,7 @@ program
     .option('-s, --indent-spaces <num_spaces>', 'Number of spaces of indentation for package.json', 4)
     .option('-i, --version-increment [level]', 'Version increment level', 'patch')
     .option('-V, --verbose', 'Verbose mode', false)
+    .option('-U, --upgrade-level [level]', 'Package version upgrade level', 'major')
     .on('--help', utilities.printExamples)
     .parse(process.argv);
 
@@ -24,6 +25,9 @@ function validateOptions() {
     if (!validIncrementLevels.includes(program.versionIncrement)) {
         return invalidOption('Invalid version increment level provided. Valid levels are: ' + validIncrementLevels);
     }
+    if (!validIncrementLevels.includes(program.upgradeLevel)) {
+        return invalidOption('Invalid dependency version upgrade increment level provided. Valid levels are: ' + validIncrementLevels);
+    }
 
     VERBOSE = program.verbose;
 
@@ -33,7 +37,8 @@ function validateOptions() {
         options: {
             indentationSpaces: parseInt(program.indentSpaces, 10),
             versionPrefix: program.versionPrefix,
-            versionIncrement: program.versionIncrement
+            versionIncrement: program.versionIncrement,
+            dependencyUpgradeLevel: program.upgradeLevel
         }
     });
 }

--- a/bin/updep.js
+++ b/bin/updep.js
@@ -12,7 +12,7 @@ program
     .option('-s, --indent-spaces <num_spaces>', 'Number of spaces of indentation for package.json', 4)
     .option('-i, --version-increment [level]', 'Version increment level', 'patch')
     .option('-V, --verbose', 'Verbose mode', false)
-    .option('-U, --upgrade-level [level]', 'Package version upgrade level', 'major')
+    .option('-U, --upgrade-level [level]', 'Dependency version upgrade level', 'major')
     .on('--help', utilities.printExamples)
     .parse(process.argv);
 

--- a/bin/utils/utilities.js
+++ b/bin/utils/utilities.js
@@ -69,10 +69,10 @@ function updateDeps(params, listKey) {
 
 function getLatestVersion(packageName) {
     return request({
-        url: 'http://registry.npmjs.org/' + packageName + '/latest',
+        url: 'http://registry.npmjs.org/' + packageName,
         json: true
     })
-        .then((response) => response.body.version);
+        .then((response) => response.body['dist-tags'].latest);
 }
 
 function constructVersionNumber(prefix, versionNumber) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "updep",
-    "version": "1.1.0",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -25,9 +25,9 @@
             }
         },
         "acorn": {
-            "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.6.tgz",
-            "integrity": "sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+            "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
             "dev": true
         },
         "acorn-jsx": {
@@ -306,9 +306,9 @@
             "dev": true
         },
         "eslint": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.1.tgz",
-            "integrity": "sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==",
+            "version": "5.13.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.13.0.tgz",
+            "integrity": "sha512-nqD5WQMisciZC5EHZowejLKQjWGuFS5c70fxqSKlnDME+oz9zmE8KTlX+lHSg+/5wsC/kf9Q9eMkC8qS3oM2fg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -340,7 +340,6 @@
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.8.2",
                 "path-is-inside": "^1.0.2",
-                "pluralize": "^7.0.0",
                 "progress": "^2.0.0",
                 "regexpp": "^2.0.1",
                 "semver": "^5.5.1",
@@ -655,21 +654,21 @@
             "dev": true
         },
         "inquirer": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-            "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+            "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
+                "ansi-escapes": "^3.2.0",
+                "chalk": "^2.4.2",
                 "cli-cursor": "^2.1.0",
                 "cli-width": "^2.0.0",
-                "external-editor": "^3.0.0",
+                "external-editor": "^3.0.3",
                 "figures": "^2.0.0",
-                "lodash": "^4.17.10",
+                "lodash": "^4.17.11",
                 "mute-stream": "0.0.7",
                 "run-async": "^2.2.0",
-                "rxjs": "^6.1.0",
+                "rxjs": "^6.4.0",
                 "string-width": "^2.1.0",
                 "strip-ansi": "^5.0.0",
                 "through": "^2.3.6"
@@ -964,12 +963,6 @@
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
-        "pluralize": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-            "dev": true
-        },
         "prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1205,9 +1198,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "6.7.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
-                    "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+                    "version": "6.8.1",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
+                    "integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "author": "mrodrig",
     "name": "updep",
     "description": "An automated dependency upgrade module for NodeJS.",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "repository": {
         "type": "git",
         "url": "http://github.com/mrodrig/updep.git"
@@ -33,7 +33,7 @@
         "commander": "2.19.0"
     },
     "devDependencies": {
-        "eslint": "5.12.1",
+        "eslint": "5.13.0",
         "mocha": "5.2.0"
     },
     "engines": {


### PR DESCRIPTION
Add new feature for specifying the level of upgrade desired. For example, should updep just perform a patch upgrade (ie. update to the latest patch versions), minor upgrade, or major upgrade (ie. latest version of everything).

Addresses #8 